### PR TITLE
Argument overrides envvar

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 var gif = require("gulp-if");
 var argv = require("yargs").argv;
 
+if (argv['gulp-environments-internal-test']) {
+  // the tests require reloading argv more explicitly
+  argv = require("yargs").parse(process.argv);
+}
+
 var currentEnv;
 function current(env) {
   if(arguments.length > 0) {

--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@ var gif = require("gulp-if");
 var argv = require("yargs").argv;
 
 if (argv['gulp-environments-internal-test']) {
-  // the tests require loading argv more explicitly
-  argv = require("yargs").parse(process.argv);
+  // The tests require hard re-loading yargs.
+  delete require.cache[require.resolve("yargs")];
+  argv = require("yargs").argv;
 }
 
 var currentEnv;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function current(env) {
 }
 
 function reset() {
-  current(make(process.env.NODE_ENV || argv.env || "development"));
+  current(make(argv.env || process.env.NODE_ENV || "development"));
 }
 
 function make(name) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var gif = require("gulp-if");
 var argv = require("yargs").argv;
 
 if (argv['gulp-environments-internal-test']) {
-  // the tests require reloading argv more explicitly
+  // the tests require loading argv more explicitly
   argv = require("yargs").parse(process.argv);
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A library for easily adding environments (development/production) to Gulp",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha ./index.js ./test/*.js"
+    "test": "./node_modules/mocha/bin/mocha ./index.js ./test/*.js --gulp-environments-internal-test=1"
   },
   "repository": {
     "type": "git",

--- a/test/gulp-environments.js
+++ b/test/gulp-environments.js
@@ -8,6 +8,8 @@ var refresh = function(path) {
 describe("gulp-environments", function() {
   beforeEach(function() {
     delete process.env.NODE_ENV;
+
+    environments = refresh("../");
   });
 
   it("gives the environment a name", function() {
@@ -26,13 +28,24 @@ describe("gulp-environments", function() {
   });
 
   it("respects command line argument over process environment", function() {
-    process.env.NODE_ENV = "production";
-    process.argv.push("--env=development");
+    var envArg = "--env=development";
 
+    process.env.NODE_ENV = "production";
+    process.argv.push(envArg);
+
+    // Must fully refresh rather than just `.reset()` because the arguments are
+    // only loaded once, so reset won't see the new artificial argument.
     environments = refresh("../");
 
     expect(environments.development()).to.be.true;
     expect(environments.production()).to.be.false;
+
+	 // After this test is done, we need to remove the environment argument and
+	 // hard refresh again so we have a new pristine version.
+    process.argv = process.argv.filter(function(arg) {
+        return (arg !== envArg);
+    });
+    environments = refresh("../");
   });
 
   it("distinguishes between environments", function() {

--- a/test/gulp-environments.js
+++ b/test/gulp-environments.js
@@ -40,10 +40,10 @@ describe("gulp-environments", function() {
     expect(environments.development()).to.be.true;
     expect(environments.production()).to.be.false;
 
-	 // After this test is done, we need to remove the environment argument and
-	 // hard refresh again so we have a new pristine version.
+    // After this test is done, we need to remove the environment argument and
+    // hard refresh again so we have a new pristine version.
     process.argv = process.argv.filter(function(arg) {
-        return (arg !== envArg);
+      return (arg !== envArg);
     });
     environments = refresh("../");
   });

--- a/test/gulp-environments.js
+++ b/test/gulp-environments.js
@@ -8,8 +8,6 @@ var refresh = function(path) {
 describe("gulp-environments", function() {
   beforeEach(function() {
     delete process.env.NODE_ENV;
-
-    environments = refresh("../");
   });
 
   it("gives the environment a name", function() {

--- a/test/gulp-environments.js
+++ b/test/gulp-environments.js
@@ -4,10 +4,14 @@ var refresh = function(path) {
   delete require.cache[require.resolve(path)];
   return require(path);
 }
+var cleanArgv = process.argv.slice(0); // store a clone of the original argv
 
 describe("gulp-environments", function() {
   beforeEach(function() {
+    // Reset to a pristine state and hard refresh.
     delete process.env.NODE_ENV;
+    process.argv = cleanArgv;
+    environments = refresh("../");
   });
 
   it("gives the environment a name", function() {
@@ -26,10 +30,8 @@ describe("gulp-environments", function() {
   });
 
   it("respects command line argument over process environment", function() {
-    var envArg = "--env=development";
-
     process.env.NODE_ENV = "production";
-    process.argv.push(envArg);
+    process.argv.push("--env=development");
 
     // Must fully refresh rather than just `.reset()` because the arguments are
     // only loaded once, so reset won't see the new artificial argument.
@@ -37,13 +39,6 @@ describe("gulp-environments", function() {
 
     expect(environments.development()).to.be.true;
     expect(environments.production()).to.be.false;
-
-    // After this test is done, we need to remove the environment argument and
-    // hard refresh again so we have a new pristine version.
-    process.argv = process.argv.filter(function(arg) {
-      return (arg !== envArg);
-    });
-    environments = refresh("../");
   });
 
   it("distinguishes between environments", function() {

--- a/test/gulp-environments.js
+++ b/test/gulp-environments.js
@@ -1,9 +1,14 @@
 var environments = require("../");
 var expect = require("chai").expect;
+var refresh = function(path) {
+  delete require.cache[require.resolve(path)];
+  return require(path);
+}
 
 describe("gulp-environments", function() {
-  var development = environments.make("development");
-  var production = environments.make("production");
+  beforeEach(function() {
+    delete process.env.NODE_ENV;
+  });
 
   it("gives the environment a name", function() {
     var staging = environments.make("staging");
@@ -16,22 +21,32 @@ describe("gulp-environments", function() {
 
     environments.reset();
 
-    expect(development()).to.be.true;
-    expect(production()).to.be.false;
+    expect(environments.development()).to.be.true;
+    expect(environments.production()).to.be.false;
+  });
+
+  it("respects command line argument over process environment", function() {
+    process.env.NODE_ENV = "production";
+    process.argv.push("--env=development");
+
+    environments = refresh("../");
+
+    expect(environments.development()).to.be.true;
+    expect(environments.production()).to.be.false;
   });
 
   it("distinguishes between environments", function() {
-    environments.current(development);
+    environments.current(environments.development);
 
-    expect(development()).to.be.true;
-    expect(production()).to.be.false;
+    expect(environments.development()).to.be.true;
+    expect(environments.production()).to.be.false;
   });
 
   it("allows switching environments", function() {
-    environments.current(development);
-    environments.current(production);
+    environments.current(environments.development);
+    environments.current(environments.production);
 
-    expect(development()).to.be.false;
-    expect(production()).to.be.true;
+    expect(environments.development()).to.be.false;
+    expect(environments.production()).to.be.true;
   });
 });


### PR DESCRIPTION
This PR addresses the issue raised in #5 where the `NODE_ENV` variable overrides any `--env` command line argument.  _Note: It doesn't resolve that issue, since there are other issues raised there beyond the argument superseding the environment variable._

If this is accepted, it may represent a breaking change, considering the popularity of this package.